### PR TITLE
Make validation script improvements

### DIFF
--- a/verify-db-ratings.sh
+++ b/verify-db-ratings.sh
@@ -105,7 +105,7 @@ do
     exit 1
   fi
 
-  if test_integration "$APP_URL" $(( x % 5 + 1 )); then
+  if test_integration "$APP_URL" "${2}"; then
     exit 0
   fi
   sleep 10

--- a/verify-db-ratings.sh
+++ b/verify-db-ratings.sh
@@ -72,6 +72,10 @@ test_integration() {
     echo "SUCCESS: Web UI reflects DB change"
     return 0
   else
+    if [[ $(echo "${AFTER}" | grep "glyphicon-star" | grep -cv "glyphicon-star-empty") == $((4 + "${2}")) ]]; then
+      echo "SUCCESS: No changes made to database as new value is same as old value"
+      return 0
+    fi
     echo "ERROR: DB change wasn't reflected in web UI:"
     diff --suppress-common-lines <(echo "${AFTER}") <(echo "${BEFORE}")
     return 1
@@ -105,7 +109,7 @@ do
     exit 1
   fi
 
-  if test_integration "$APP_URL" "${2}"; then
+  if test_integration "$APP_URL" "${1}"; then
     exit 0
   fi
   sleep 10


### PR DESCRIPTION
Currently, the validation script is expecting the DB ratings value to be
equal to the timeout counter. This commit fixes that to instead
correctly pass in the script parameter meant to be used as the
validation value.

Also, in the current state, the verification script will exit with an error if
the requested database value is not different from the old value. This
is not really an error condition and should not result in the
verification failing. Instead, the number of stars on the returned web
page are counted to verify that the correct number is returned.